### PR TITLE
Added constants module that exposes menuconfig items to upy apps

### DIFF
--- a/firmware/components/micropython/component.mk
+++ b/firmware/components/micropython/component.mk
@@ -180,6 +180,7 @@ SRC_C =  $(addprefix esp32/,\
 	machine_ow.c \
 	modesp.c \
 	esprtcmem.c \
+	modconsts.c \
 	modmpr121.c \
 	moderc12864.c \
 	modneopixel.c \

--- a/firmware/components/micropython/esp32/modconsts.c
+++ b/firmware/components/micropython/esp32/modconsts.c
@@ -1,0 +1,45 @@
+// Include required definitions first.
+#include "sdkconfig.h"
+#include <time.h>
+#include <string.h>
+#include "py/builtin.h"
+#include "py/objlist.h"
+#include "py/objtuple.h"
+#include "py/objstr.h"
+#include "py/objint.h"
+#include "py/objtype.h"
+#include "py/stream.h"
+#include "py/smallint.h"
+#include "py/runtime.h"
+#include "lib/utils/pyexec.h"
+
+#define INT_TO_STR_EX(number) #number
+#define INT_TO_STR(number) INT_TO_STR_EX(number)
+
+STATIC const MP_DEFINE_STR_OBJ(info_firmware_name_obj, CONFIG_INFO_FIRMWARE_NAME);
+STATIC const MP_DEFINE_STR_OBJ(info_firmware_build_obj, INT_TO_STR(CONFIG_INFO_FIRMWARE_BUILD));
+
+STATIC const MP_DEFINE_STR_OBJ(info_hardware_name_obj, CONFIG_INFO_HARDWARE_NAME);
+STATIC const MP_DEFINE_STR_OBJ(info_hardware_folder_obj, CONFIG_INFO_HARDWARE_FOLDER);
+
+STATIC const MP_DEFINE_STR_OBJ(wifi_ssid_obj, CONFIG_WIFI_SSID);
+STATIC const MP_DEFINE_STR_OBJ(wifi_pass_obj, CONFIG_WIFI_PASSWORD);
+
+STATIC const mp_rom_map_elem_t consts_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_INFO_FIRMWARE_NAME),			MP_ROM_PTR(&info_firmware_name_obj) },
+    { MP_ROM_QSTR(MP_QSTR_INFO_FIRMWARE_BUILD),		    MP_ROM_PTR(&info_firmware_build_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_INFO_HARDWARE_NAME),			MP_ROM_PTR(&info_hardware_name_obj) },
+    { MP_ROM_QSTR(MP_QSTR_INFO_HARDWARE_FOLDER),		MP_ROM_PTR(&info_hardware_folder_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_WIFI_SSID),			        MP_ROM_PTR(&wifi_ssid_obj) },
+    { MP_ROM_QSTR(MP_QSTR_WIFI_PASSWORD),			    MP_ROM_PTR(&wifi_pass_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(consts_module_globals, consts_module_globals_table);
+
+// Define module object.
+const mp_obj_module_t consts_module = {
+        .base = { &mp_type_module },
+        .globals = (mp_obj_dict_t*)&consts_module_globals,
+};

--- a/firmware/components/micropython/esp32/mpconfigport.h
+++ b/firmware/components/micropython/esp32/mpconfigport.h
@@ -283,9 +283,12 @@ extern const struct _mp_obj_module_t mp_module_network;
 extern const struct _mp_obj_module_t mp_module_ymodem;
 extern const struct _mp_obj_module_t esp_module;
 
-//#ifdef CONFIG_DRIVER_HUB75_ENABLE
+// Consts module is always exposed
+extern const struct _mp_obj_module_t consts_module;
+
+#ifdef CONFIG_DRIVER_HUB75_ENABLE
 extern const struct _mp_obj_module_t hub75_module;
-//#endif
+#endif
 
 #ifdef CONFIG_DRIVER_I2C_ENABLE
 extern const struct _mp_obj_module_t i2c_module;
@@ -310,6 +313,9 @@ extern const struct _mp_obj_module_t eink_module;
 #ifdef CONFIG_DRIVER_NEOPIXEL_ENABLE
 extern const struct _mp_obj_module_t neopixel_module;
 #endif
+
+// Consts module is always exposed
+#define BUILTIN_MODULE_CONSTS { MP_OBJ_NEW_QSTR(MP_QSTR_consts), (mp_obj_t)&consts_module },
 
 #ifdef CONFIG_MICROPY_USE_REQUESTS
 extern const struct _mp_obj_module_t mp_module_requests;
@@ -395,6 +401,7 @@ extern const struct _mp_obj_module_t mp_module_bluetooth;
 #define BUILTIN_MODULE_HUB75
 #endif
 
+
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_OBJ_NEW_QSTR(MP_QSTR_utime),    (mp_obj_t)&utime_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_uos),      (mp_obj_t)&uos_module }, \
@@ -403,10 +410,12 @@ extern const struct _mp_obj_module_t mp_module_bluetooth;
     { MP_OBJ_NEW_QSTR(MP_QSTR_network),  (mp_obj_t)&mp_module_network }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_ymodem),   (mp_obj_t)&mp_module_ymodem }, \
 	{ MP_OBJ_NEW_QSTR(MP_QSTR_uhashlib), (mp_obj_t)&mp_module_uhashlib }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_esp),      (mp_obj_t)&esp_module }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_consts),   (mp_obj_t)&consts_module }, \
 	BUILTIN_MODULE_CURL \
     BUILTIN_MODULE_REQUESTS \
 	BUILTIN_MODULE_BLUETOOTH \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_esp), (mp_obj_t)&esp_module }, \
+    BUILTIN_MODULE_CONSTS \
     BUILTIN_MODULE_I2C \
     BUILTIN_MODULE_MPR121 \
     BUILTIN_MODULE_ERC12864 \

--- a/firmware/components/micropython/esp32/mpconfigport.h
+++ b/firmware/components/micropython/esp32/mpconfigport.h
@@ -411,11 +411,10 @@ extern const struct _mp_obj_module_t mp_module_bluetooth;
     { MP_OBJ_NEW_QSTR(MP_QSTR_ymodem),   (mp_obj_t)&mp_module_ymodem }, \
 	{ MP_OBJ_NEW_QSTR(MP_QSTR_uhashlib), (mp_obj_t)&mp_module_uhashlib }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_esp),      (mp_obj_t)&esp_module }, \
-    { MP_OBJ_NEW_QSTR(MP_QSTR_consts),   (mp_obj_t)&consts_module }, \
+    BUILTIN_MODULE_CONSTS \
 	BUILTIN_MODULE_CURL \
     BUILTIN_MODULE_REQUESTS \
 	BUILTIN_MODULE_BLUETOOTH \
-    BUILTIN_MODULE_CONSTS \
     BUILTIN_MODULE_I2C \
     BUILTIN_MODULE_MPR121 \
     BUILTIN_MODULE_ERC12864 \


### PR DESCRIPTION
Have to clean up imports sometime (only affects buildtimes, and even that insignificantly), and couldn't get the firmware version to expose as int properly (currently exposed as string).

Seems like a nice way to have the menuconfig settings exposed to upy though. What do you think?