### PR TITLE
Add driver support for the SAMD coprocessor on the Disobey 2019 badge

### DIFF
--- a/firmware/components/driver_io_disobey_samd/Kconfig
+++ b/firmware/components/driver_io_disobey_samd/Kconfig
@@ -1,0 +1,15 @@
+menu "Driver: Disobey 2019 SAMD I/O"
+	config DRIVER_DISOBEY_SAMD_ENABLE
+		bool "Enable the Disobey 2019 SAMD I/O driver"
+		default n
+
+	config I2C_ADDR_DISOBEY_SAMD
+		depends on DRIVER_DISOBEY_SAMD_ENABLE
+		int "SAMD I2C address"
+		default 48
+
+	config PIN_NUM_DISOBEY_SAMD_INT
+		depends on DRIVER_DISOBEY_SAMD_ENABLE
+		int "GPIO pin used for SAMD interrupt"
+		default 25
+endmenu

--- a/firmware/components/driver_io_disobey_samd/component.mk
+++ b/firmware/components/driver_io_disobey_samd/component.mk
@@ -1,0 +1,3 @@
+COMPONENT_ADD_INCLUDEDIRS := .
+
+COMPONENT_EXTRA_INCLUDES := $(PROJECT_PATH)/components/driver_bus_i2c/include

--- a/firmware/components/driver_io_disobey_samd/driver_disobey_samd.c
+++ b/firmware/components/driver_io_disobey_samd/driver_disobey_samd.c
@@ -1,0 +1,233 @@
+#include <sdkconfig.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
+#include <esp_log.h>
+#include <driver/gpio.h>
+
+#include "driver_i2c.h"
+#include "include/driver_disobey_samd.h"
+
+#ifdef CONFIG_DRIVER_DISOBEY_SAMD_ENABLE
+
+static const char *TAG = "Disobey I/O";
+
+// mutex for accessing driver_disobey_samd_state, driver_disobey_samd_handlers, etc..
+xSemaphoreHandle driver_disobey_samd_mux = NULL;
+
+// semaphore to trigger disobey_samd interrupt handling
+xSemaphoreHandle driver_disobey_samd_intr_trigger = NULL;
+
+// handlers per disobey_samd port.
+driver_disobey_samd_intr_t driver_disobey_samd_handler = NULL;
+void* driver_disobey_samd_arg[12] = { NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL};
+
+int driver_disobey_samd_read_state()
+{
+	uint8_t state[2];
+	esp_err_t res = driver_i2c_read_reg(CONFIG_I2C_ADDR_DISOBEY_SAMD, 0, state, 2);
+
+	if (res != ESP_OK) {
+		ESP_LOGE(TAG, "i2c read state error %d", res);
+		return -1;
+	}
+
+	int value = state[0] + (state[1] << 8);
+
+	ESP_LOGD(TAG, "i2c read state 0x%04x", value);
+
+	return value;
+}
+
+int driver_disobey_samd_read_touch()
+{
+	int touch = driver_disobey_samd_read_state() & 0x3F;
+	//ets_printf("driver_disobey_samd: read touch: 0x%02X\n", touch);
+	return touch;
+}
+
+int driver_disobey_samd_read_usb()
+{
+	return (driver_disobey_samd_read_state()>>6) & 0x01;
+}
+
+int driver_disobey_samd_read_battery()
+{
+	return driver_disobey_samd_read_state()>>8 & 0xFF;
+}
+
+static inline esp_err_t driver_disobey_samd_write_reg(uint8_t reg, uint8_t value)
+{
+	esp_err_t res = driver_i2c_write_reg(CONFIG_I2C_ADDR_DISOBEY_SAMD, reg, value);
+
+	if (res != ESP_OK) {
+		ESP_LOGE(TAG, "i2c write reg(0x%02x, 0x%02x): error %d", reg, value, res);
+		return res;
+	}
+
+	ESP_LOGD(TAG, "i2c write reg(0x%02x, 0x%02x): ok", reg, value);
+
+	return res;
+}
+
+static inline esp_err_t driver_disobey_samd_write_reg32(uint8_t reg, uint32_t value)
+{
+	esp_err_t res = driver_i2c_write_reg32(CONFIG_I2C_ADDR_DISOBEY_SAMD, reg, value);
+
+	if (res != ESP_OK) {
+		ESP_LOGE(TAG, "i2c write reg32(0x%08x, 0x%02x): error %d", reg, value, res);
+		return res;
+	}
+
+	ESP_LOGD(TAG, "i2c write reg32(0x%02x, 0x%08x): ok", reg, value);
+
+	return res;
+}
+
+esp_err_t driver_disobey_samd_write_backlight(uint8_t value)
+{
+	return driver_disobey_samd_write_reg(disobey_samd_CMD_BACKLIGHT, value);
+}
+
+esp_err_t driver_disobey_samd_write_led(uint8_t led, uint8_t r, uint8_t g, uint8_t b)
+{
+	uint32_t value = led + (r << 8) + (g << 16) + (b << 24);
+	return driver_disobey_samd_write_reg32(disobey_samd_CMD_LED, value);
+}
+
+esp_err_t driver_disobey_samd_write_buzzer(uint16_t freqency, uint16_t duration)
+{
+	uint32_t value = freqency + (duration << 16);
+	return driver_disobey_samd_write_reg32(disobey_samd_CMD_BUZZER, value);
+}
+
+esp_err_t driver_disobey_samd_write_off()
+{
+	return driver_disobey_samd_write_reg32(disobey_samd_CMD_OFF, 0);
+}
+
+void driver_disobey_samd_intr_task(void *arg)
+{
+	// we cannot use I2C in the interrupt handler, so we
+	// create an extra thread for this..
+
+	int old_state = 0;
+	while (1)
+	{
+		if (xSemaphoreTake(driver_disobey_samd_intr_trigger, portMAX_DELAY))
+		{
+			int state;
+			while (1)
+			{
+				state = driver_disobey_samd_read_touch();
+				if (state != -1)
+					break;
+
+				ESP_LOGE(TAG, "failed to read status.");
+				vTaskDelay(1000 / portTICK_PERIOD_MS);
+			}
+
+			int pressed = 0;
+			int released = 0;
+
+			for (uint8_t i = 0; i<6; i++) {
+				if (((state>>i)&0x01)&&(!((old_state>>i)&0x01))) pressed |= (1<<i);
+				if (((old_state>>i)&0x01)&&(!((state>>i)&0x01))) released |= (1<<i);
+			}
+
+			if (state != old_state) {
+				xSemaphoreTake(driver_disobey_samd_mux, portMAX_DELAY);
+				driver_disobey_samd_intr_t handler = driver_disobey_samd_handler;
+				xSemaphoreGive(driver_disobey_samd_mux);
+
+				if (handler != NULL) {
+					handler(pressed, released);
+				}
+			}
+
+			old_state = state;
+		}
+	}
+}
+
+void driver_disobey_samd_intr_handler(void *arg)
+{ /* in interrupt handler */
+	int gpio_state = gpio_get_level(CONFIG_PIN_NUM_DISOBEY_SAMD_INT);
+
+#ifdef CONFIG_DRIVER_DISOBEY_SAMD_DEBUG
+	static int gpio_last_state = -1;
+	if (gpio_state != -1 && gpio_last_state != gpio_state)
+	{
+		ets_printf("driver_disobey_samd: I2C Int %s\n", gpio_state == 0 ? "up" : "down");
+	}
+	gpio_last_state = gpio_state;
+#endif // CONFIG_SHA_DRIVER_disobey_samd_DEBUG
+
+	if (gpio_state == 0) {
+		xSemaphoreGiveFromISR(driver_disobey_samd_intr_trigger, NULL);
+	}
+}
+
+esp_err_t driver_disobey_samd_init(void)
+{
+	static bool driver_disobey_samd_init_done = false;
+
+	if (driver_disobey_samd_init_done)
+		return ESP_OK;
+
+	ESP_LOGD(TAG, "init called");
+
+	esp_err_t res = driver_i2c_init();
+	if (res != ESP_OK) return res;
+
+	driver_disobey_samd_mux = xSemaphoreCreateMutex();
+	if (driver_disobey_samd_mux == NULL) return ESP_ERR_NO_MEM;
+
+	driver_disobey_samd_intr_trigger = xSemaphoreCreateBinary();
+	if (driver_disobey_samd_intr_trigger == NULL) return ESP_ERR_NO_MEM;
+
+	res = gpio_isr_handler_add(CONFIG_PIN_NUM_DISOBEY_SAMD_INT, driver_disobey_samd_intr_handler, NULL);
+	if (res != ESP_OK) return res;
+
+	gpio_config_t io_conf = {
+		.intr_type    = GPIO_INTR_ANYEDGE,
+		.mode         = GPIO_MODE_INPUT,
+		.pin_bit_mask = 1LL << CONFIG_PIN_NUM_DISOBEY_SAMD_INT,
+		.pull_down_en = 0,
+		.pull_up_en   = 0,
+	};
+	res = gpio_config(&io_conf);
+	if (res != ESP_OK) return res;
+	xTaskCreate(&driver_disobey_samd_intr_task, "disobey_samd interrupt task", 4096, NULL, 10, NULL);
+	xSemaphoreGive(driver_disobey_samd_intr_trigger);
+	driver_disobey_samd_init_done = true;
+	ESP_LOGD(TAG, "init done");
+	return ESP_OK;
+}
+
+void driver_disobey_samd_set_interrupt_handler(driver_disobey_samd_intr_t handler)
+{
+	if (driver_disobey_samd_mux == NULL)
+	{ // allow setting handlers when driver_disobey_samd is not initialized yet.
+		driver_disobey_samd_handler = handler;
+	} else {
+		xSemaphoreTake(driver_disobey_samd_mux, portMAX_DELAY);
+		driver_disobey_samd_handler = handler;
+		xSemaphoreGive(driver_disobey_samd_mux);
+	}
+}
+
+esp_err_t driver_disobey_samd_get_touch_info(struct driver_disobey_samd_touch_info *info)
+{
+	int value = driver_disobey_samd_read_touch();
+	if (value == -1) return ESP_FAIL; // need more-specific error?
+	info->touch_state = value;
+	return ESP_OK;
+}
+
+#endif // CONFIG_DRIVER_DISOBEY_SAMD_ENABLE

--- a/firmware/components/driver_io_disobey_samd/include/driver_disobey_samd.h
+++ b/firmware/components/driver_io_disobey_samd/include/driver_disobey_samd.h
@@ -1,0 +1,127 @@
+#ifndef DRIVER_DISOBEY_SAMD_H
+#define DRIVER_DISOBEY_SAMD_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <esp_err.h>
+
+#define DISOBEY_SAMD_BUTTON_LEFT   0
+#define DISOBEY_SAMD_BUTTON_UP     1
+#define DISOBEY_SAMD_BUTTON_BACK   2
+#define DISOBEY_SAMD_BUTTON_OK     3
+#define DISOBEY_SAMD_BUTTON_DOWN   4
+#define DISOBEY_SAMD_BUTTON_RIGHT  5
+
+#define disobey_samd_CMD_LED       0x01
+#define disobey_samd_CMD_BACKLIGHT 0x02
+#define disobey_samd_CMD_BUZZER    0x03
+#define disobey_samd_CMD_OFF       0x04
+
+__BEGIN_DECLS
+
+/** interrupt handler type */
+typedef void (*driver_disobey_samd_intr_t)(int, int);
+
+/** touch info */
+struct driver_disobey_samd_touch_info {
+	/** bitmapped touch state */
+	uint32_t touch_state;
+};
+
+/**
+ * Initialize internal structures and interrupt-handling for the disobey_samd.
+ * @note This should be called before using any other methods.
+ *   The only exception is driver_disobey_samd_set_interrupt_handler().
+ * @return ESP_OK on success; any other value indicates an error
+ */
+extern esp_err_t driver_disobey_samd_init(void);
+
+/**
+ * Configure interrupt handler for a specific pin.
+ * @param pin the pin-number on the disobey_samd chip.
+ * @param handler the handler to be called on an interrupt.
+ * @param arg the argument passed on to the handler.
+ * @note It is safe to set the interrupt handler before a call to driver_disobey_samd_init().
+ */
+extern void driver_disobey_samd_set_interrupt_handler(driver_disobey_samd_intr_t handler);
+
+/**
+ * Retrieve the disobey_samd status.
+ * @return the status registers; or -1 on error
+ */
+extern int driver_disobey_samd_get_interrupt_status(void);
+
+/**
+ * Retrieve disobey_samd touch info
+ * @param info touch info will be written to this structure.
+ * @return ESP_OK on success; any other value indicates an error
+ */
+extern esp_err_t driver_disobey_samd_get_touch_info(struct driver_disobey_samd_touch_info *info);
+
+/**
+ * Read raw touch, usb and battery statusses
+ * @param None
+ * @return ...
+ */
+
+extern int driver_disobey_samd_read_state(void);
+
+/**
+ * Read touch button status
+ * @param None
+ * @return one bit per button
+ */
+
+extern int driver_disobey_samd_read_touch(void);
+
+/**
+ * Read USB connection status
+ * @param None
+ * @return 1 if connected, 0 if disconnected
+ */
+
+extern int driver_disobey_samd_read_usb(void);
+
+/**
+ * Read battery level
+ * @param None
+ * @return ...
+ */
+
+extern int driver_disobey_samd_read_battery(void);
+
+/**
+ * Set backlight PWM value
+ * @param PWM value (0-255)
+ * @return ESP_OK on success; any other value indicates an error
+ */
+
+extern esp_err_t driver_disobey_samd_write_backlight(uint8_t value);
+
+/**
+ * Set led color
+ * @param led (0-5), red (0-255), green (0-255) and blue (0-255)
+ * @return ESP_OK on success; any other value indicates an error
+ */
+
+extern esp_err_t driver_disobey_samd_write_led(uint8_t led, uint8_t r, uint8_t g, uint8_t b);
+
+/**
+ * Set buzzer frequency and duration
+ * @param frequency, duration (0 is forever)
+ * @return ESP_OK on success; any other value indicates an error
+ */
+
+extern esp_err_t driver_disobey_samd_write_buzzer(uint16_t freqency, uint16_t duration);
+
+/**
+ * Turn off LEDs, buzzer and backlight
+ * @param None
+ * @return ESP_OK on success; any other value indicates an error
+ */
+
+extern esp_err_t driver_disobey_samd_write_off(void);
+
+__END_DECLS
+
+#endif // DRIVER_DISOBEY_SAMD_H

--- a/firmware/components/micropython/component.mk
+++ b/firmware/components/micropython/component.mk
@@ -106,6 +106,7 @@ MP_EXTRA_INC += -I$(PROJECT_PATH)/components/driver_display_erc12864/include
 MP_EXTRA_INC += -I$(PROJECT_PATH)/components/driver_display_ssd1306/include
 MP_EXTRA_INC += -I$(PROJECT_PATH)/components/driver_led_neopixel/include
 MP_EXTRA_INC += -I$(PROJECT_PATH)/components/driver_display_eink/include
+MP_EXTRA_INC += -I$(PROJECT_PATH)/components/driver_io_disobey_samd/include
 
 
 
@@ -187,6 +188,7 @@ SRC_C =  $(addprefix esp32/,\
 	modssd1306.c \
 	modeink.c \
 	modespnow.c \
+	moddisobeysamd.c \
 	)
 
 ifdef CONFIG_DRIVER_I2C_ENABLE

--- a/firmware/components/micropython/esp32/moddisobeysamd.c
+++ b/firmware/components/micropython/esp32/moddisobeysamd.c
@@ -1,0 +1,76 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "py/mperrno.h"
+#include "py/mphal.h"
+#include "py/runtime.h"
+
+#include <driver_disobey_samd.h>
+
+#ifdef CONFIG_DRIVER_DISOBEY_SAMD_ENABLE
+
+STATIC mp_obj_t samd_backlight(mp_uint_t n_args, const mp_obj_t *args) {
+  driver_disobey_samd_write_backlight(mp_obj_get_int(args[0]));
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(samd_backlight_obj, 1, 1, samd_backlight);
+
+STATIC mp_obj_t samd_led(mp_uint_t n_args, const mp_obj_t *args) {
+  driver_disobey_samd_write_led(mp_obj_get_int(args[0]),mp_obj_get_int(args[1]),mp_obj_get_int(args[2]),mp_obj_get_int(args[3]));
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(samd_led_obj, 4, 4, samd_led);
+
+STATIC mp_obj_t samd_buzzer(mp_uint_t n_args, const mp_obj_t *args) {
+  driver_disobey_samd_write_buzzer(mp_obj_get_int(args[0]),mp_obj_get_int(args[1]));
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(samd_buzzer_obj, 2, 2, samd_buzzer);
+
+STATIC mp_obj_t samd_off() {
+  driver_disobey_samd_write_off();
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(samd_off_obj, samd_off);
+
+STATIC mp_obj_t samd_read_usb() {
+  return mp_obj_new_int(driver_disobey_samd_read_usb());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(samd_read_usb_obj, samd_read_usb);
+
+STATIC mp_obj_t samd_read_battery() {
+  return mp_obj_new_int(driver_disobey_samd_read_battery());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(samd_read_battery_obj, samd_read_battery);
+
+STATIC mp_obj_t samd_read_touch() {
+  return mp_obj_new_int(driver_disobey_samd_read_touch());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(samd_read_touch_obj, samd_read_touch);
+
+STATIC mp_obj_t samd_read_state() {
+  return mp_obj_new_int(driver_disobey_samd_read_state());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(samd_read_state_obj, samd_read_state);
+
+STATIC const mp_rom_map_elem_t samd_module_globals_table[] = {
+    {MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_samd)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_backlight), (mp_obj_t)&samd_backlight_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_led), (mp_obj_t)&samd_led_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_buzzer), (mp_obj_t)&samd_buzzer_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_off), (mp_obj_t)&samd_off_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_read_usb), (mp_obj_t)&samd_read_usb_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_read_battery), (mp_obj_t)&samd_read_battery_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_read_touch), (mp_obj_t)&samd_read_touch_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_read_state), (mp_obj_t)&samd_read_state_obj},
+    };
+
+static MP_DEFINE_CONST_DICT(samd_module_globals, samd_module_globals_table);
+
+const mp_obj_module_t samd_module = {
+	.base = {&mp_type_module},
+	.globals = (mp_obj_dict_t *)&samd_module_globals,
+};
+
+#endif // CONFIG_DRIVER_DISOBEY_SAMD_ENABLE

--- a/firmware/components/micropython/esp32/mpconfigport.h
+++ b/firmware/components/micropython/esp32/mpconfigport.h
@@ -305,6 +305,10 @@ extern const struct _mp_obj_module_t erc12864_module;
 extern const struct _mp_obj_module_t ssd1306_module;
 #endif
 
+#ifdef CONFIG_DRIVER_DISOBEY_SAMD_ENABLE
+extern const struct _mp_obj_module_t samd_module;
+#endif
+
 #ifdef CONFIG_DRIVER_EINK_ENABLE
 extern const struct _mp_obj_module_t eink_module;
 #endif
@@ -379,6 +383,12 @@ extern const struct _mp_obj_module_t mp_module_bluetooth;
 #define BUILTIN_MODULE_SSD1306
 #endif
 
+#ifdef CONFIG_DRIVER_DISOBEY_SAMD_ENABLE
+#define BUILTIN_MODULE_DISOBEY_SAMD { MP_OBJ_NEW_QSTR(MP_QSTR_samd), (mp_obj_t)&samd_module },
+#else
+#define BUILTIN_MODULE_DISOBEY_SAMD
+#endif
+
 #ifdef CONFIG_DRIVER_EINK_ENABLE
 #define BUILTIN_MODULE_EINK { MP_OBJ_NEW_QSTR(MP_QSTR_eink), (mp_obj_t)&eink_module },
 #else
@@ -418,6 +428,7 @@ extern const struct _mp_obj_module_t mp_module_bluetooth;
     BUILTIN_MODULE_NEOPIXEL \
     BUILTIN_MODULE_HUB75 \
     BUILTIN_MODULE_EINK \
+    BUILTIN_MODULE_DISOBEY_SAMD \
     { MP_OBJ_NEW_QSTR(MP_QSTR_espnow), (mp_obj_t)&espnow_module }, \
 
 #define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \

--- a/firmware/main/Kconfig.projbuild
+++ b/firmware/main/Kconfig.projbuild
@@ -48,6 +48,6 @@ menu "OTA update & WiFi"
 		default ""
 endmenu
 
-menu "Drivers"
-    source "../components/driver_*/Kconfig"
-endmenu
+#menu "Drivers"
+#    source "../components/driver_*/Kconfig"
+#endmenu

--- a/firmware/main/platform.c
+++ b/firmware/main/platform.c
@@ -18,12 +18,13 @@ esp_err_t isr_init()
 void platform_init()
 {
 	if (isr_init() != ESP_OK) restart();
-	INIT_DRIVER(vspi)
-	INIT_DRIVER(i2c)
-	INIT_DRIVER(hub75)
-	INIT_DRIVER(mpr121)
-	INIT_DRIVER(neopixel)
-	INIT_DRIVER(erc12864)
-	INIT_DRIVER(ssd1306)
-	INIT_DRIVER(eink)
+	INIT_DRIVER(vspi)         //Generic VSPI bus driver
+	INIT_DRIVER(i2c)          //Generic I2C bus driver
+	INIT_DRIVER(hub75)        //LED matrix as found on the CampZone 2019 badge
+	INIT_DRIVER(mpr121)       //I/O expander with touch inputs as found on the SHA2017 and HackerHotel 2019 badges
+	INIT_DRIVER(neopixel)     //Addressable LEDs as found on the SHA2017 and HackerHotel 2019 badges
+	INIT_DRIVER(erc12864)     //128x64 LCD screen as found on the Disobey 2019 badge
+	INIT_DRIVER(ssd1306)      //128x64 OLED screen as found on the Disobey 2020 badge
+	INIT_DRIVER(eink)         //296x128 e-ink display as found on the SHA2017 and HackerHotel 2019 badges
+	INIT_DRIVER(disobey_samd) //I/O via the SAMD co-processor on the Disobey 2019 badge
 }


### PR DESCRIPTION
This adds the driver for the SAMD coprocesor.