### PR TITLE
Cz19 feature/button and menu rework

### DIFF
--- a/firmware/python_modules/campzone2019/buttons.py
+++ b/firmware/python_modules/campzone2019/buttons.py
@@ -1,31 +1,63 @@
 import machine
+from defines import *
 
 _gpios     = []
 _pins      = []
-_callbacks = []
+
+button_mappings = []
+
+def init_button_mapping():
+	global button_mappings
+	button_mappings.append(_default_button_mapping())
+	return True
+
+def clear_button_mapping():
+	global button_mappings
+	if len(button_mappings) > 1:
+		button_mappings = button_mappings[:-1]
+	return True
+
+def assign(gpio, action = None):
+	global button_mappings
+	button_mappings[-1][gpio] = action
+	return True
+	
+def unassign(gpio):
+	return assign(gpio, None)
 
 def _cb(pin):
 	position = _pins.index(pin)
 	gpio = _gpios[position]
-	callback = _callbacks[position]
-	if callable(callback):
+	callback = button_mappings[-1][gpio]
+	if callback and callable(callback):
 		callback(not pin.value())
 	
-def register(gpio, action=None):
+def _register(gpio):
 	if gpio in _gpios:
 		return False
 	pin = machine.Pin(gpio, machine.Pin.IN, handler=_cb, trigger=machine.Pin.IRQ_ANYEDGE, debounce=100, acttime=100)
 	_gpios.append(gpio)
 	_pins.append(pin)
-	_callbacks.append(action)
 	return True
 
-def assign(gpio, action):
-	if not gpio in _gpios:
-		return False
-	position = _gpios.index(gpio)
-	_callbacks[position] = action
-	return True
-	
-def unassign(gpio):
-	return assign(gpio, None)
+def _default_button_mapping():
+	return {
+		BTN_UP: None,
+		BTN_DOWN: None,
+		BTN_LEFT: None,
+		BTN_RIGHT: None,
+		BTN_A: None,
+		BTN_B: None
+	}
+
+def _register_all_handlers():
+	_register(BTN_UP)
+	_register(BTN_DOWN)
+	_register(BTN_LEFT)
+	_register(BTN_RIGHT)
+	_register(BTN_A)
+	_register(BTN_B)
+
+register = assign
+init_button_mapping()
+_register_all_handlers()

--- a/firmware/python_modules/campzone2019/setupwifi.py
+++ b/firmware/python_modules/campzone2019/setupwifi.py
@@ -1,4 +1,4 @@
-import rgb, network, machine, time, buttons, defines, system
+import rgb, network, machine, time, buttons, defines, system, uinterface
 from default_icons import animation_connecting_wifi
 
 chosen_ssid = ''
@@ -18,23 +18,6 @@ sta_if.disconnect()
 ssid_result = sta_if.scan()
 ssid_list = [ssid[0].decode('utf-8', 'ignore') for ssid in ssid_result]
 
-
-def render_ssid():
-    rgb.clear()
-    rgb.scrolltext(ssid_list[cur_selected])
-
-def up_1(pressed):
-    global cur_selected
-    if pressed:
-        cur_selected = max(cur_selected - 1, 0)
-        render_ssid()
-
-def down_1(pressed):
-    global cur_selected
-    if pressed:
-        cur_selected = min(cur_selected + 1, len(ssid_list))
-        render_ssid()
-
 def ok(pressed):
     global accepted
     if pressed:
@@ -45,14 +28,14 @@ def render_pass():
     rgb.text(chosen_pass)
 
 
-def up_2(pressed):
+def up(pressed):
     global chosen_pass
     if pressed:
         new_char = chr(ord(chosen_pass[cur_selected]) + 1)
         chosen_pass = chosen_pass[0:cur_selected] + new_char + chosen_pass[cur_selected+1:]
         render_pass()
 
-def down_2(pressed):
+def down(pressed):
     global chosen_pass
     if pressed:
         new_char = chr(ord(chosen_pass[cur_selected]) - 1)
@@ -89,29 +72,24 @@ rgb.framerate(20)
 rgb.setfont(rgb.FONT_6x3)
 rgb.scrolltext('Select network')
 time.sleep(5)
-render_ssid()
 
-buttons.register(defines.BTN_UP, up_1)
-buttons.register(defines.BTN_DOWN, down_1)
-buttons.register(defines.BTN_A, ok)
-buttons.register(defines.BTN_B, back)
+choice = uinterface.menu(ssid_list)
+if choice is None:
+        system.reboot()
 
-while not accepted:
-    time.sleep(0.1)
+chosen_ssid = ssid_list[choice]
 
-chosen_ssid = ssid_list[cur_selected]
-
-buttons.unassign(defines.BTN_UP)
-buttons.unassign(defines.BTN_DOWN)
 accepted = False
 cur_selected = 0
 rgb.clear()
+rgb.framerate(20)
+rgb.setfont(rgb.FONT_6x3)
 rgb.scrolltext('Enter password:')
 time.sleep(5)
 render_pass()
 
-buttons.assign(defines.BTN_UP, up_2)
-buttons.assign(defines.BTN_DOWN, down_2)
+buttons.register(defines.BTN_UP, up)
+buttons.register(defines.BTN_DOWN, down)
 buttons.register(defines.BTN_LEFT, left)
 buttons.register(defines.BTN_RIGHT, right)
 

--- a/firmware/python_modules/campzone2019/uinterface.py
+++ b/firmware/python_modules/campzone2019/uinterface.py
@@ -1,0 +1,94 @@
+import rgb, buttons, defines, time
+
+MENU_NO_OPERATION = 0
+MENU_SELECT_ITEM = 2
+MENU_MOVE_BACK = 4
+
+DEFAULT_CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
+FONT = rgb.FONT_7x5
+FONT_HEIGHT = 7
+FONT_WIDTH = 5
+SCREEN_WIDTH = 32
+
+menu_state = {
+    "selected" : 0,
+    "items": [],
+    "pressed_button": MENU_NO_OPERATION
+}
+
+def menu(items, selected = 0):
+    state = _menu_init_display_and_state(items, selected)
+    while state["pressed_button"] == MENU_NO_OPERATION:
+        time.sleep(0.1)
+    _menu_exit_routine()
+    if state["pressed_button"] == MENU_SELECT_ITEM:
+        return state["selected"]
+    else:
+        return None
+
+def text_input(charset = DEFAULT_CHARSET):
+    pass
+
+def _menu_init_display_and_state(items, selected):
+    global menu_state
+    menu_state["items"] = items
+    menu_state["selected"] = selected
+    menu_state["pressed_button"] = MENU_NO_OPERATION
+    rgb.clear()
+    rgb.framerate(20)
+    rgb.setfont(FONT)
+    _menu_register_callbacks()
+    _draw_menu_item(items[selected])
+    return menu_state
+
+def _menu_exit_routine():
+    rgb.clear()
+    buttons.clear_button_mapping()
+
+def _menu_register_callbacks():
+    buttons.init_button_mapping()
+    buttons.register(defines.BTN_A, _menu_select_callback)
+    buttons.register(defines.BTN_B, _menu_back_callback)
+    buttons.register(defines.BTN_UP, _menu_up_callback)
+    buttons.register(defines.BTN_DOWN, _menu_down_callback)
+
+def _menu_up_callback(pressed):
+    global menu_state
+    if pressed:
+        selected = menu_state["selected"]
+        item_count = len(menu_state["items"])
+        selected -= 1
+        if (selected < 0):
+            selected = item_count - 1
+
+        menu_state["selected"] = selected
+        _draw_menu_item(menu_state["items"][selected])
+
+def _menu_down_callback(pressed):
+    global menu_state
+    if pressed:
+        selected = menu_state["selected"]
+        item_count = len(menu_state["items"])
+        selected += 1
+        if (selected >= item_count):
+            selected = 0
+
+        menu_state["selected"] = selected
+        _draw_menu_item(menu_state["items"][selected])
+
+def _menu_back_callback(pressed):
+    if pressed:
+        _menu_add_button_press_state(MENU_MOVE_BACK)
+
+def _menu_select_callback(pressed):
+    if pressed:
+        _menu_add_button_press_state(MENU_SELECT_ITEM)
+
+def _menu_add_button_press_state(button_state):
+    global menu_state
+    menu_state["pressed_button"] = menu_state["pressed_button"] | button_state
+
+def _draw_menu_item(item):
+    rgb.clear()
+    rgb.scrolltext(item)


### PR DESCRIPTION
* Allows multiple button mappings to be switched so that apps may use submodules with input handling routines
* First version of the user interface helper module with a menu input helper
* Changed the WiFi setup module so that it uses the new menu input helper