### PR TITLE
Fix leds_enable for SHA and HH

### DIFF
--- a/firmware/python_modules/hackerhotel2019/badge.py
+++ b/firmware/python_modules/hackerhotel2019/badge.py
@@ -54,7 +54,7 @@ def leds_init():
 	pass
 
 def leds_enable():
-	mpr121.set(10, true);
+	mpr121.set(10, True);
 
 def safe_mode():
 	return False

--- a/firmware/python_modules/sha2017/badge.py
+++ b/firmware/python_modules/sha2017/badge.py
@@ -54,7 +54,7 @@ def leds_init():
 	pass
 
 def leds_enable():
-	mpr121.set(10, true);
+	mpr121.set(10, True);
 
 def safe_mode():
 	return False


### PR DESCRIPTION
The app I was testing with doesn't work even with this change due to
https://github.com/badgeteam/ESP32-platform-firmware/issues/81

If we're replacing this API, perhaps leds_enable should disappear.