### PR TITLE
Add xtensa to PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
   - make --version
   - du -hs
   - unzip -p toolchain/xtensa-esp32-elf-linux64.zip xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0.tar | tar xvf -
-  - export PATH=$PATH:$(pwd)/xtensa-esp32-elf/bin
   - ./build.sh
   - du -hs
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 git submodule update --init --recursive || exit 1
 cd firmware
-export PATH="$PATH:`pwd`/xtensa-esp32-elf/bin"
+export PATH="$PATH:$(pwd)/xtensa-esp32-elf/bin"
 bash mpy_cross.sh || exit 1
 rm build -rf
 make clean

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 git submodule update --init --recursive || exit 1
-export PATH="$PATH:`pwd`/xtensa-esp32-elf/bin"
 cd firmware
+export PATH="$PATH:`pwd`/xtensa-esp32-elf/bin"
 bash mpy_cross.sh || exit 1
 rm build -rf
 make clean

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 git submodule update --init --recursive || exit 1
-cd firmware
 export PATH="$PATH:$(pwd)/xtensa-esp32-elf/bin"
+cd firmware
 bash mpy_cross.sh || exit 1
 rm build -rf
 make clean

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 git submodule update --init --recursive || exit 1
+export PATH="$PATH:`pwd`/xtensa-esp32-elf/bin"
 cd firmware
 bash mpy_cross.sh || exit 1
 rm build -rf

--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-source set_env.sh
 git submodule update --init --recursive
 cd firmware
 bash mpy_cross.sh

--- a/erase.sh
+++ b/erase.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-source set_env.sh
 python2 esp-idf/components/esptool_py/esptool/esptool.py --port `ls /dev/tty{USB0,.wchusbserial*,.SLAB_USBtoUART,ACMx} 2>/dev/null` erase_flash

--- a/flash.sh
+++ b/flash.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-source set_env.sh
+export PATH="$PATH:`pwd`/xtensa-esp32-elf/bin"
 cd firmware
 make flash

--- a/flash.sh
+++ b/flash.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-export PATH="$PATH:`pwd`/xtensa-esp32-elf/bin"
+export PATH="$PATH:$(pwd)/xtensa-esp32-elf/bin"
 cd firmware
 make flash

--- a/incremental_build.sh
+++ b/incremental_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 git submodule update --init --recursive
 cd firmware
-export PATH="$PATH:`pwd`/xtensa-esp32-elf/bin"
+export PATH="$PATH:$(pwd)/xtensa-esp32-elf/bin"
 bash mpy_cross.sh
 make -j8

--- a/incremental_build.sh
+++ b/incremental_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-source set_env.sh
 git submodule update --init --recursive
 cd firmware
+export PATH="$PATH:`pwd`/xtensa-esp32-elf/bin"
 bash mpy_cross.sh
 make -j8

--- a/monitor.sh
+++ b/monitor.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-source set_env.sh
 cd firmware
 make monitor


### PR DESCRIPTION
At the end, so if you have one manually configured it still takes precedence

This worked before but was lost in #121 . With this patch most of the
documentation change in #127 should no longer be needed.