### PR TITLE
Added CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+set( ENV{IDF_PATH} ${CMAKE_CURRENT_LIST_DIR}/esp-idf )
+set( ENV{PATH} ENV{PATH}:${CMAKE_CURRENT_LIST_DIR}/xtensa-esp32-elf/bin:${CMAKE_CURRENT_LIST_DIR}/esp-idf/tools:/usr/bin )
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(new-esp32-firmware)


### PR DESCRIPTION
This patch adds a CMake config that makes development easier. It is recognised immediately by CLion, without needing to set any flags or env vars.

All esp-idf includes are resolved correctly upon opening the project the first time, and building / flashing is available using the normal CLion _run_ button.

I hope this lowers the barrier of entry for new devs.