### PR TITLE
Fixes #158

### DIFF
--- a/firmware/python_modules/disobey2020/identification.py
+++ b/firmware/python_modules/disobey2020/identification.py
@@ -1,20 +1,70 @@
 import voltages as _voltages
-_voltage   = _voltages.identification()
-_names     = ["Techie", "Fixer", "Corporate", "Netrunner", "Rocker", "Prototype"]
-_values    = [830, 1460, 2110, 2710, 3300, 9999]
-_badgeType = len(_values)-1
+_voltage    = _voltages.identification()
+_names      = ["Techie", "Fixer", "Rocker", "Netrunner", "Corporate"]
+_badgeTypes = {
+    2000: {"type": b"t", "name":"Techie"},
+    5100: {"type": b"f", "name":"Fixer"},
+    12000: {"type": b"r", "name":"Rocker"},
+    27000: {"type": b"n", "name":"Nethunter"},
+    100000: {"type": b"c", "name":"Corporate"}
+}
+_voltages    = [830, 1460, 2110, 2710, 3300, 9999]
 
-# Determine badge type
-for i in range(len(_values)):
-	if _voltage < _values[i]:
-		_badgeType = i
-		break
+_r1 = 10000
 
-def getName():
-	return _names[_badgeType]
+_adcRef = 3.9
+_v_div = 3.3
+_adcResolution = 4096
 
-def getType():
-	return _badgeType
 
 def getVoltage():
 	return _voltage
+
+def takeClosest(myList, myNumber):
+    """
+    Assumes myList is sorted. Returns closest value to myNumber.
+
+    If two numbers are equally close, return the smallest number.
+    """
+    pos = bisect_left(myList, myNumber)
+    if pos == 0:
+        return myList[0]
+    if pos == len(myList):
+        return myList[-1]
+    before = myList[pos - 1]
+    after = myList[pos]
+    if after - myNumber < myNumber - before:
+        return after
+    else:
+        return before
+
+def measure_resistor():
+    """
+    Reads ADC value on type-detection pin
+
+    Returns measured resistance as integer
+    """
+    meas = getVoltage()
+    adc_voltage = (meas / _adcResolution) * _adcRef
+    r2 = int((_r1 * adc_voltage) / (_v_div - adc_voltage))
+    return r2
+
+def detect_type():
+    """
+    Takes measured resistance and matches it to key LUT
+
+    Returns badge type from LUT.
+    If detection fails, returns False
+    """
+    res = measure_resistor()
+    if res > 0 and res < 1000000:
+        closest_match = min(_badgeTypes, key=lambda x:abs(x - res))
+        return _badgeTypes[closest_match]
+    else:
+    	return False
+
+def getName():
+	return detect_type()["name"]
+
+def getType():
+	return detect_type()["type"]

--- a/firmware/python_modules/disobey2020/voltages.py
+++ b/firmware/python_modules/disobey2020/voltages.py
@@ -12,6 +12,7 @@ _vusb.atten(machine.ADC.ATTN_11DB)
 
 _vident = machine.ADC(PIN_VIDENT)
 _vident.atten(machine.ADC.ATTN_11DB)
+_vident.width(machine.ADC.WIDTH_12BIT)
 
 def usb():
 	'''
@@ -32,4 +33,4 @@ def identification():
 	Read identification voltage
 	:return: integer, voltage in mV
 	'''
-	return int(_vident.read()*1.94)
+	return _vident.read()


### PR DESCRIPTION
Fixes identification and enables easier HW development as the badge type is now defined directly by resistor values. Tested with Proto3 badges and all five categories.

Long-term tests with full range of battery voltages to be done, but this should not be a significant risk, as the reference voltage should stay relatively stabile as long as the badge is operational.