### PR TITLE
[Disobey 2020] Cleanup: voltages, identification and touch button verification

### DIFF
--- a/firmware/python_modules/disobey2020/_mpr121mapping.py
+++ b/firmware/python_modules/disobey2020/_mpr121mapping.py
@@ -1,34 +1,23 @@
 # MPR121 settings for the Disobey 2020 badge
-
 import identification
+
+# Get machine readable identifier of the badge type
 _badgeType = identification.getType()
 
-if _badgeType == 0: # Techie
-	buttons = [4,5,7,6,1,3,0,2,-1] #A, B, START, SELECT, DOWN, RIGHT, UP, LEFT, FLASH (-1 for not available)
-	pinToName = ["UP", "DOWN", "LEFT", "RIGHT", "A", "B", "SELECT", "START", "LED1", "LED2", "LED_PWR", "DISPLAY_PWR"]
-	correction_factor = 2
-	#verification = [65,49,56,54,48,60,65,74,0,0,0,0]
-elif _badgeType == 1: # Fixer
-	buttons = [4,5,7,6,1,3,0,2,-1] #A, B, START, SELECT, DOWN, RIGHT, UP, LEFT, FLASH (-1 for not available)
-	pinToName = ["UP", "DOWN", "LEFT", "RIGHT", "A", "B", "SELECT", "START", "LED1", "LED2", "LED_PWR", "DISPLAY_PWR"]
-	correction_factor = 2
-	verification = [65,49,56,54,48,60,65,74,0,0,0,0]
-elif _badgeType == 2: # Corporate
-	buttons = [4,5,7,6,1,3,0,2,-1] #A, B, START, SELECT, DOWN, RIGHT, UP, LEFT, FLASH (-1 for not available)
-	pinToName = ["UP", "DOWN", "LEFT", "RIGHT", "A", "B", "SELECT", "START", "LED1", "LED2", "LED_PWR", "DISPLAY_PWR"]
-	correction_factor = 2
-	#verification = [65,49,56,54,48,60,65,74,0,0,0,0]
-elif _badgeType == 3: # Netrunner
-	buttons = [4,5,7,6,1,3,0,2,-1] #A, B, START, SELECT, DOWN, RIGHT, UP, LEFT, FLASH (-1 for not available)
-	pinToName = ["UP", "DOWN", "LEFT", "RIGHT", "A", "B", "SELECT", "START", "LED1", "LED2", "LED_PWR", "DISPLAY_PWR"]
-	correction_factor = 2
-	#verification = [65,49,56,54,48,60,65,74,0,0,0,0]
-elif _badgeType == 4: # Rocker
-	buttons = [4,5,7,6,1,3,0,2,-1] #A, B, START, SELECT, DOWN, RIGHT, UP, LEFT, FLASH (-1 for not available)
-	pinToName = ["UP", "DOWN", "LEFT", "RIGHT", "A", "B", "SELECT", "START", "LED1", "LED2", "LED_PWR", "DISPLAY_PWR"]
-	correction_factor = 2
-	#verification = [65,49,56,54,48,60,65,74,0,0,0,0]
-else: # Unknown / prototype
-	buttons = [4,5,7,6,1,3,0,2,-1] #A, B, START, SELECT, DOWN, RIGHT, UP, LEFT, FLASH (-1 for not available)
-	pinToName = ["UP", "DOWN", "LEFT", "RIGHT", "A", "B", "SELECT", "START", "LED1", "LED2", "LED_PWR", "DISPLAY_PWR"]
-	correction_factor = 2
+# Parameters which are the same for every badge variant
+buttons = [4,5,7,6,1,3,0,2,-1] #A, B, START, SELECT, DOWN, RIGHT, UP, LEFT, FLASH (-1 for not available)
+pinToName = ["UP", "DOWN", "LEFT", "RIGHT", "A", "B", "SELECT", "START", "LED1", "LED2", "LED_PWR", "DISPLAY_PWR"]
+correction_factor = 2
+
+# Calibration reference values per badge variant
+if _badgeType == b"t": # Techie
+	verification = [65,51,57,56,45,63,64,72,0,0,0,0]
+elif _badgeType == b"f": # Fixer
+	verification = [61,54,60,54,52,60,58,60,0,0,0,0]
+elif _badgeType == b"c": # Corporate
+	verification = [67,47,58,48,50,58,65,76,0,0,0,0]
+elif _badgeType == b"n": # Netrunner
+	#verification = [61,62,54,0,0,57,70,78,0,0,0,0]
+	pass # Verification for netrunner is disabled because of missing data for channels 3 and 4
+elif _badgeType == b"r": # Rocker
+	verification = [61,53,64,50,45,64,67,73,0,0,0,0]

--- a/firmware/python_modules/disobey2020/dashboard/launcher.py
+++ b/firmware/python_modules/disobey2020/dashboard/launcher.py
@@ -21,6 +21,8 @@ about_icon = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00 \x00\x00\x00 \x01
 
 nickname_icon = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00 \x00\x00\x00 \x01\x03\x00\x00\x00I\xb4\xe8\xb7\x00\x00\x00\x06PLTE\x00\x00\x00\xff\xff\xff\xa5\xd9\x9f\xdd\x00\x00\x00\tpHYs\x00\x00\x16%\x00\x00\x16%\x01IR$\xf0\x00\x00\x00\x19tEXtSoftware\x00www.inkscape.org\x9b\xee<\x1a\x00\x00\x00FIDAT\x08\x99c`@\x03\xec\x0f\x80\x84\xfc\x0f !c\x01$,d\x80\x84\x01\x0f\x0e\x02\xac\x04\xac\x98\xff\x03L/\x1a\xf8\xff\x1f(\xfe\xff\xff\x03\x06\xf6\x06\xc6\x07\x0c\xfc\x0c\x0c\x1f\x18\xf8\x18\x18\n\xb0\x12@#\r\xd0\xb4\x03\x00\xfe}\x11 \x01G-\xe6\x00\x00\x00\x00IEND\xaeB`\x82'
 
+charge_icon = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00 \x00\x00\x00 \x01\x00\x00\x00\x00[\x01GY\x00\x00\x00OIDAT\x08\xd7c` \x020\xc3\x08\xe6gu\x0c\x0c\xec\xcf\xea\x1b\x18xX\x18\x81\x04\x0f\xe3\x01 \xc1\xf0\x80\x81G\xa2\xc0\x80\x81G\xfe\x03\x90\xb0O\x00\x12\x16 \x82!\x01(\xc1p\xf0\x00\x88h``\xff9\x1f\xa8\xf7\xe7<\xa01@\xadH\x86\xe2\x05\x005W\x11d\x9d9\x1a\x9f\x00\x00\x00\x00IEND\xaeB`\x82'
+
 def drawMessageBox(text):
 	width = display.getTextWidth(text, "org18")
 	height = display.getTextHeight(text, "org18")
@@ -139,17 +141,18 @@ display.flush()
 term.header(True, "Loading...")
 apps = listApps()
 amountOfUserApps = len(apps)
-apps.append({"path":"dashboard.home",                  "name":"Home",               "icon":home_icon,      "category":"system"})
-apps.append({"path":"dashboard.installer",             "name":"Installer",          "icon":installer_icon, "category":"system"})
+apps.append(  {"path":"dashboard.home",                  "name":"Home",               "icon":home_icon,      "category":"system"})
+apps.append(  {"path":"dashboard.installer",             "name":"Installer",          "icon":installer_icon, "category":"system"})
 if amountOfUserApps > 0:
-	apps.append({"path":"dashboard.tools.uninstall",       "name":"Remove an app",      "icon":trash_icon,     "category":"system"})
-	apps.append({"path":"dashboard.tools.update_apps",     "name":"Update apps",        "icon":installer_icon, "category":"system"})
+  apps.append({"path":"dashboard.tools.uninstall",       "name":"Remove an app",      "icon":trash_icon,     "category":"system"})
+  apps.append({"path":"dashboard.tools.update_apps",     "name":"Update apps",        "icon":installer_icon, "category":"system"})
 if haveSD:
-	apps.append({"path":"dashboard.tools.movetosd",        "name":"Move from/to SD",    "icon":settings_icon, "category":"system"})
-apps.append({"path":"dashboard.tools.update_firmware", "name":"Update firmware",    "icon":installer_icon, "category":"system"})
-apps.append({"path":"dashboard.settings.nickname",     "name":"Configure nickname", "icon":nickname_icon,  "category":"system"})
-apps.append({"path":"dashboard.settings.wifi",         "name":"WiFi setup",         "icon":settings_icon,  "category":"system"})
-apps.append({"path":"dashboard.other.about",           "name":"About",              "icon":about_icon,     "category":"system"})
+  apps.append({"path":"dashboard.tools.movetosd",        "name":"Move from/to SD",    "icon":settings_icon,  "category":"system"})
+apps.append(  {"path":"dashboard.tools.update_firmware", "name":"Update firmware",    "icon":installer_icon, "category":"system"})
+apps.append(  {"path":"dashboard.settings.nickname",     "name":"Configure nickname", "icon":nickname_icon,  "category":"system"})
+apps.append(  {"path":"dashboard.settings.wifi",         "name":"WiFi setup",         "icon":settings_icon,  "category":"system"})
+apps.append(  {"path":"dashboard.tools.battery_monitor", "name":"Voltages",           "icon":charge_icon,    "category":"system"})
+apps.append(  {"path":"dashboard.other.about",           "name":"About",              "icon":about_icon,     "category":"system"})
 
 currentApp = 0
 

--- a/firmware/python_modules/disobey2020/identification.py
+++ b/firmware/python_modules/disobey2020/identification.py
@@ -1,70 +1,38 @@
+# Badge variant identification for the Disobey 2020 badge
 import voltages as _voltages
-_voltage    = _voltages.identification()
-_names      = ["Techie", "Fixer", "Corporate", "Netrunner", "Rocker"]
-_badgeTypes = {
+
+# Types
+_badge_types = {
     2000: {"type": b"t", "name":"Techie"},
     5100: {"type": b"f", "name":"Fixer"},
     12000: {"type": b"c", "name":"Corporate"},
     27000: {"type": b"n", "name":"Netrunner"},
     100000: {"type": b"r", "name":"Rocker"}
 }
-_voltages    = [830, 1460, 2110, 2710, 3300, 9999]
 
+# Determine badge type
+_voltage = _voltages.identification()
 _r1 = 10000
+_v_div = 3300
+_r2 = int((_r1 * _voltage) / (_v_div - _voltage))
 
-_adcRef = 3.9
-_v_div = 3.3
-_adcResolution = 4096
+if _r2 > 0 and _r2 < 1000000:
+    _closest_match = min(_badge_types, key=lambda x:abs(x - _r2))
+    _badge_type = _badge_types[_closest_match]
+else:
+    _badge_type = {"type": b"u", "name":"Unknown"}
 
-
-def getVoltage():
-	return _voltage
-
-def takeClosest(myList, myNumber):
-    """
-    Assumes myList is sorted. Returns closest value to myNumber.
-
-    If two numbers are equally close, return the smallest number.
-    """
-    pos = bisect_left(myList, myNumber)
-    if pos == 0:
-        return myList[0]
-    if pos == len(myList):
-        return myList[-1]
-    before = myList[pos - 1]
-    after = myList[pos]
-    if after - myNumber < myNumber - before:
-        return after
-    else:
-        return before
-
-def measure_resistor():
-    """
-    Reads ADC value on type-detection pin
-
-    Returns measured resistance as integer
-    """
-    meas = getVoltage()
-    adc_voltage = (meas / _adcResolution) * _adcRef
-    r2 = int((_r1 * adc_voltage) / (_v_div - adc_voltage))
-    return r2
-
-def detect_type():
-    """
-    Takes measured resistance and matches it to key LUT
-
-    Returns badge type from LUT.
-    If detection fails, returns False
-    """
-    res = measure_resistor()
-    if res > 0 and res < 1000000:
-        closest_match = min(_badgeTypes, key=lambda x:abs(x - res))
-        return _badgeTypes[closest_match]
-    else:
-    	return False
-
+# Public functions
 def getName():
-	return detect_type()["name"]
+    '''
+    Get the human readable name of the current badge type
+    :return: string, full type name
+    '''
+    return _badge_type["name"]
 
 def getType():
-	return detect_type()["type"]
+    '''
+    Get the machine readable identifier of the current badge type
+    :return: bytestring, identifier
+    '''
+    return _badge_type["type"]

--- a/firmware/python_modules/disobey2020/voltages.py
+++ b/firmware/python_modules/disobey2020/voltages.py
@@ -1,36 +1,44 @@
+# Analog voltage readout for the Disobey 2020 badge
 import machine
 
+# Pins
 PIN_VBAT   = 39
 PIN_VUSB   = 36
 PIN_VIDENT = 32
 
+# ADCs
 _vbat = machine.ADC(PIN_VBAT)
 _vbat.atten(machine.ADC.ATTN_11DB)
+_vbat.width(machine.ADC.WIDTH_12BIT)
 
 _vusb = machine.ADC(PIN_VUSB)
 _vusb.atten(machine.ADC.ATTN_11DB)
+_vusb.width(machine.ADC.WIDTH_12BIT)
 
 _vident = machine.ADC(PIN_VIDENT)
 _vident.atten(machine.ADC.ATTN_11DB)
 _vident.width(machine.ADC.WIDTH_12BIT)
 
+# Public functions
 def usb():
-	'''
-	Read USB input voltage
-	:return: integer, voltage in mV
-	'''
-	return int(_vusb.read()*1.97)
+    '''
+    Read USB input voltage
+    :return: integer, voltage in mV
+    '''
+    return int((_vusb.read() / 4096) * 3.9 * 2000)
+    # Note: physically connected through a 100k/100k resistor divider
 
 def battery():
-	'''
-	Read battery voltage
-	:return: integer, voltage in mV
-	'''
-	return int(_vbat.read()*1.94)
+    '''
+    Read battery voltage
+    :return: integer, voltage in mV
+    '''
+    return int((_vbat.read() / 4096) * 3.9 * 2000)
+    # Note: physically connected through a 100k/100k resistor divider
 
 def identification():
-	'''
-	Read identification voltage
-	:return: integer, voltage in mV
-	'''
-	return _vident.read()
+    '''
+    Read identification voltage
+    :return: integer, voltage in mV
+    '''
+    return int((_vident.read() / 4096) * 3.9 * 1000)


### PR DESCRIPTION
This PR cleans up the voltage readout python code, the identification python code and adds the MPR121 touch-button verification values for all varianst except netrunner.

@Zokol Please provide the calibration output table of a verified working Netrunner badge (with the short between channels 3 and 4 removed) so that the verification values for that variant can be added too.