### PR TITLE
Update factory checks value to 3

### DIFF
--- a/firmware/python_modules/campzone2019/factory_checks.py
+++ b/firmware/python_modules/campzone2019/factory_checks.py
@@ -30,7 +30,7 @@ def next_check():
         rgb.clear()
         rgb.background((0, 50, 0))
         rgb.text("Done!", CYAN, (4, 1))
-        machine.nvs_setint('system', 'factory_checked', 2)
+        machine.nvs_setint('system', 'factory_checked', 3)
         return
 
     background, textcolor, x_pos, text, gpio = checklist.pop(0)

--- a/firmware/python_modules/campzone2019/factory_checks.py
+++ b/firmware/python_modules/campzone2019/factory_checks.py
@@ -1,6 +1,12 @@
 import buttons, machine
 import defines, rgb
 
+import system
+currentState = machine.nvs_getint('system', 'factory_checked') or 0
+if currentState >= 2:
+    machine.nvs_setint('system', 'factory_checked', 3)
+    system.home()
+
 RED     = (255, 0, 0)
 GREEN   = (0, 255, 0)
 BLUE    = (0, 0, 255)


### PR DESCRIPTION
I changed the factory checks target to 3 for the SHA2017 badge. This change should be applied to all badges to prevent a "factory check bootloop" from happening.