### PR TITLE
HTTPS certificate checking for Micropython

### DIFF
--- a/firmware/components/micropython/extmod/modussl_mbedtls.c
+++ b/firmware/components/micropython/extmod/modussl_mbedtls.c
@@ -217,7 +217,7 @@ STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
         const byte *cert = (const byte*)mp_obj_str_get_data(args->cert.u_obj, &cert_len);
         
         if (!MP_OBJ_IS_TYPE(args->cert.u_obj, &mp_type_bytes)) { //Not a bytes() object
-            printf("Parsing supplied certificate as ASCII string.\n");
+            //printf("Parsing supplied certificate as ASCII string.\n");
             // len should include terminating null
             ret = mbedtls_x509_crt_parse(&o->cacert, cert, cert_len + 1); //(this parses normal ASCII certificates)
             if(ret < 0) {
@@ -226,7 +226,7 @@ STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
                 goto cleanup;
             }
         } else { // bytes() object
-            printf("Parsing supplied certificate as BINARY.\n");
+            //printf("Parsing supplied certificate as BINARY.\n");
             ret = mbedtls_x509_crt_parse_der(&o->cacert, cert, cert_len + 1); //(the DER encoding is a binary encoding)
             if(ret < 0) {
                 printf("Unable to parse the supplied DER certificate. Error 0x%d!\n", ret);
@@ -411,12 +411,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ssl_wrap_socket_obj, 1, mod_ssl_wrap_socke
 
 static mp_obj_t mod_ssl_verify_letsencrypt(mp_obj_t obj_state) {
     global_load_letsencrypt_root = mp_obj_get_int(obj_state);
+    return mp_const_none;
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ssl_verify_letsencrypt_obj, mod_ssl_verify_letsencrypt);
 
 static mp_obj_t mod_ssl_disable_warning(mp_obj_t obj_state) {
     global_no_cert_warning_disabled = mp_obj_get_int(obj_state);
+    return mp_const_none;
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ssl_disable_warning_obj, mod_ssl_disable_warning);
@@ -427,9 +429,10 @@ static mp_obj_t mod_ssl_debug_level(mp_obj_t obj_state) {
         mp_raise_ValueError("Valid range is 0 to 4.");
     }
     global_debug_level = level;
+    return mp_const_none;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ssl_disable_warning_obj, mod_ssl_disable_warning);
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ssl_debug_level_obj, mod_ssl_debug_level);
 
 STATIC const mp_rom_map_elem_t mp_module_ssl_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ussl) },

--- a/firmware/components/micropython/extmod/modussl_mbedtls.c
+++ b/firmware/components/micropython/extmod/modussl_mbedtls.c
@@ -5,7 +5,7 @@
  *
  * Copyright (c) 2016 Linaro Ltd.
  * Copyright (c) 2018 LoBo (https://github.com/loboris)
- * Copyright (c) 2020 Renze (https://badge.team)
+ * Copyright (c) 2020 BADGE.TEAM (https://badge.team)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -76,24 +76,19 @@ struct ssl_args {
     mp_arg_val_t server_hostname;
 };
 
+bool global_load_letsencrypt_root = false;
+bool global_no_cert_warning_disabled = false;
+uint8_t global_debug_level = 0;
+
 STATIC const mp_obj_type_t ussl_socket_type;
 
 #ifdef CONFIG_MBEDTLS_DEBUG
 STATIC void mbedtls_debug(void *ctx, int level, const char *file, int line, const char *str) {
     (void)ctx;
     (void)level;
-    printf("DBG:%s:%04d: %s\n", file, line, str);
+    printf("[mbedtls] %s:%04d: %s\n", file, line, str);
 }
 #endif
-
-// TODO: FIXME!
-STATIC int null_entropy_func(void *data, unsigned char *output, size_t len) {
-    (void)data;
-    (void)output;
-    (void)len;
-    // enjoy random bytes
-    return 0;
-}
 
 STATIC int _mbedtls_ssl_send(void *ctx, const byte *buf, size_t len) {
     mp_obj_t sock = *(mp_obj_t*)ctx;
@@ -147,7 +142,7 @@ STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
     mbedtls_ctr_drbg_init(&o->ctr_drbg);
     #ifdef CONFIG_MBEDTLS_DEBUG
     // Debug level (0-4)
-    mbedtls_debug_set_threshold(4);
+    mbedtls_debug_set_threshold(global_debug_level);
     #endif
 
     mbedtls_entropy_init(&o->entropy);
@@ -189,32 +184,74 @@ STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
     mbedtls_ssl_set_bio(&o->ssl, &o->sock, _mbedtls_ssl_send, _mbedtls_ssl_recv, NULL);
 
     if (args->key.u_obj != MP_OBJ_NULL) {
+        // The key argument was supplied, running in server mode
         size_t key_len;
         const byte *key = (const byte*)mp_obj_str_get_data(args->key.u_obj, &key_len);
         // len should include terminating null
         ret = mbedtls_pk_parse_key(&o->pkey, key, key_len + 1, NULL, 0);
-        assert(ret == 0);
+        if(ret < 0) {
+            printf("Unable to parse the supplied key. Error 0x%d!\n", ret);
+            mp_raise_OSError(MP_EIO);
+            goto cleanup;
+        }
 
         size_t cert_len;
         const byte *cert = (const byte*)mp_obj_str_get_data(args->cert.u_obj, &cert_len);
         // len should include terminating null
         ret = mbedtls_x509_crt_parse(&o->cert, cert, cert_len + 1);
-        assert(ret == 0);
+        if(ret < 0) {
+            printf("Unable to parse the supplied certificate. Error 0x%d!\n", ret);
+            mp_raise_OSError(MP_EIO);
+            goto cleanup;
+        }
 
         ret = mbedtls_ssl_conf_own_cert(&o->conf, &o->cert, &o->pkey);
-        assert(ret == 0);
-		printf("USING AVAILABLE KEY");
-    } else {
-		//Letsencrypt
-		printf("USING LETSENCRYPT\n");
-                mbedtls_ssl_conf_authmode(&o->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
-		ret = mbedtls_x509_crt_parse_der(&o->cacert, letsencrypt, LETSENCRYPT_LENGTH);
         if(ret < 0) {
-			ESP_LOGE(TAG, "mbedtls_x509_crt_parse_der(): error %d!", -ret);
+            printf("Unable to configure the supplied certificate. Error 0x%d!\n", ret);
             mp_raise_OSError(MP_EIO);
-		}
-		mbedtls_ssl_conf_ca_chain(&o->conf, &o->cacert, NULL);
-	}
+            goto cleanup;
+        }
+    } else if (args->cert.u_obj != MP_OBJ_NULL) {
+        // A certificate was supplied, running in client mode with custom certificate
+        size_t cert_len;
+        const byte *cert = (const byte*)mp_obj_str_get_data(args->cert.u_obj, &cert_len);
+        
+        if (!MP_OBJ_IS_TYPE(args->cert.u_obj, &mp_type_bytes)) { //Not a bytes() object
+            printf("Parsing supplied certificate as ASCII string.\n");
+            // len should include terminating null
+            ret = mbedtls_x509_crt_parse(&o->cacert, cert, cert_len + 1); //(this parses normal ASCII certificates)
+            if(ret < 0) {
+                printf("Unable to parse the supplied certificate. Error 0x%d!\n", ret);
+                mp_raise_OSError(MP_EIO);
+                goto cleanup;
+            }
+        } else { // bytes() object
+            printf("Parsing supplied certificate as BINARY.\n");
+            ret = mbedtls_x509_crt_parse_der(&o->cacert, cert, cert_len + 1); //(the DER encoding is a binary encoding)
+            if(ret < 0) {
+                printf("Unable to parse the supplied DER certificate. Error 0x%d!\n", ret);
+                mp_raise_OSError(MP_EIO);
+                goto cleanup;
+            }
+        }
+        mbedtls_ssl_conf_ca_chain(&o->conf, &o->cacert, NULL);
+        mbedtls_ssl_conf_authmode(&o->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+    } else if (global_load_letsencrypt_root) {
+        // Client mode with Letsencrypt certificate verification enabled
+        ret = mbedtls_x509_crt_parse_der(&o->cacert, letsencrypt, LETSENCRYPT_LENGTH); //(the DER encoding is a binary encoding)
+        if(ret < 0) {
+            printf("Unable to parse the built-in Letsencrypt certificate!\nmbedtls_x509_crt_parse_der(): error 0x%d!\n", ret);
+            mp_raise_OSError(MP_EIO);
+            goto cleanup;
+        }
+        mbedtls_ssl_conf_ca_chain(&o->conf, &o->cacert, NULL);
+        mbedtls_ssl_conf_authmode(&o->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+    } else if (global_no_cert_warning_disabled) {
+        // Client mode without certificate verification enabled, but with the warning actively disabled. So we do nothing.
+    } else {
+        // Client mode without certificate verification enabled
+        printf("\nWarning: TLS certificate will not be verified because a root certificate is not available.\nPlease visit https://docs.badge.team for more information.\n\n");
+    }
 
     while ((ret = mbedtls_ssl_handshake(&o->ssl)) != 0) {
         if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
@@ -372,9 +409,34 @@ STATIC mp_obj_t mod_ssl_wrap_socket(size_t n_args, const mp_obj_t *pos_args, mp_
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(mod_ssl_wrap_socket_obj, 1, mod_ssl_wrap_socket);
 
+static mp_obj_t mod_ssl_verify_letsencrypt(mp_obj_t obj_state) {
+    global_load_letsencrypt_root = mp_obj_get_int(obj_state);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ssl_verify_letsencrypt_obj, mod_ssl_verify_letsencrypt);
+
+static mp_obj_t mod_ssl_disable_warning(mp_obj_t obj_state) {
+    global_no_cert_warning_disabled = mp_obj_get_int(obj_state);
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ssl_disable_warning_obj, mod_ssl_disable_warning);
+
+static mp_obj_t mod_ssl_debug_level(mp_obj_t obj_state) {
+    int level = mp_obj_get_int(obj_state);
+    if (level < 0 || level > 4) {
+        mp_raise_ValueError("Valid range is 0 to 4.");
+    }
+    global_debug_level = level;
+}
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(mod_ssl_disable_warning_obj, mod_ssl_disable_warning);
+
 STATIC const mp_rom_map_elem_t mp_module_ssl_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ussl) },
     { MP_ROM_QSTR(MP_QSTR_wrap_socket), MP_ROM_PTR(&mod_ssl_wrap_socket_obj) },
+    { MP_ROM_QSTR(MP_QSTR_verify_letsencrypt), MP_ROM_PTR(&mod_ssl_verify_letsencrypt_obj) },
+    { MP_ROM_QSTR(MP_QSTR_disable_warning), MP_ROM_PTR(&mod_ssl_disable_warning_obj) },
+    { MP_ROM_QSTR(MP_QSTR_debug_level), MP_ROM_PTR(&mod_ssl_debug_level_obj) },
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ssl_globals, mp_module_ssl_globals_table);

--- a/firmware/components/micropython/extmod/modussl_mbedtls.c
+++ b/firmware/components/micropython/extmod/modussl_mbedtls.c
@@ -72,6 +72,7 @@ typedef struct _mp_obj_ssl_socket_t {
 struct ssl_args {
     mp_arg_val_t key;
     mp_arg_val_t cert;
+    mp_arg_val_t cacert;
     mp_arg_val_t server_side;
     mp_arg_val_t server_hostname;
 };
@@ -211,12 +212,12 @@ STATIC mp_obj_ssl_socket_t *socket_new(mp_obj_t sock, struct ssl_args *args) {
             mp_raise_OSError(MP_EIO);
             goto cleanup;
         }
-    } else if (args->cert.u_obj != MP_OBJ_NULL) {
-        // A certificate was supplied, running in client mode with custom certificate
+    } else if (args->cacert.u_obj != MP_OBJ_NULL) {
+        // A CA certificate was supplied, running in client mode with custom certificate
         size_t cert_len;
-        const byte *cert = (const byte*)mp_obj_str_get_data(args->cert.u_obj, &cert_len);
+        const byte *cert = (const byte*)mp_obj_str_get_data(args->cacert.u_obj, &cert_len);
         
-        if (!MP_OBJ_IS_TYPE(args->cert.u_obj, &mp_type_bytes)) { //Not a bytes() object
+        if (!MP_OBJ_IS_TYPE(args->cacert.u_obj, &mp_type_bytes)) { //Not a bytes() object
             //printf("Parsing supplied certificate as ASCII string.\n");
             // len should include terminating null
             ret = mbedtls_x509_crt_parse(&o->cacert, cert, cert_len + 1); //(this parses normal ASCII certificates)
@@ -394,6 +395,7 @@ STATIC mp_obj_t mod_ssl_wrap_socket(size_t n_args, const mp_obj_t *pos_args, mp_
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_key, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_cert, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_cacert, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_server_side, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_server_hostname, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
     };

--- a/firmware/python_modules/shared/urequests.py
+++ b/firmware/python_modules/shared/urequests.py
@@ -1,3 +1,5 @@
+# Extended to allow for supplying a certificate by BADGE.TEAM
+
 import usocket
 
 class Response:
@@ -16,9 +18,11 @@ class Response:
     @property
     def content(self):
         if self._cached is None:
-            self._cached = self.raw.read()
-            self.raw.close()
-            self.raw = None
+            try:
+                self._cached = self.raw.read()
+            finally:
+                self.raw.close()
+                self.raw = None
         return self._cached
 
     @property
@@ -30,7 +34,7 @@ class Response:
         return ujson.loads(self.content)
 
 
-def request(method, url, data=None, json=None, headers={}, stream=None, timeout=None, redirect=5):
+def request(method, url, data=None, json=None, headers={}, stream=None, cert=None):
     try:
         proto, dummy, host, path = url.split("/", 3)
     except ValueError:
@@ -48,56 +52,61 @@ def request(method, url, data=None, json=None, headers={}, stream=None, timeout=
         host, port = host.split(":", 1)
         port = int(port)
 
-    ai = usocket.getaddrinfo(host, port)
-    addr = ai[0][-1]
-    s = usocket.socket()
-    if timeout:
-	s.settimeout(timeout)
-    s.connect(addr)
-    if proto == "https:":
-        s = ussl.wrap_socket(s, server_hostname=host)
-    s.write(b"%s /%s HTTP/1.0\r\n" % (method, path))
-    if not "Host" in headers:
-        s.write(b"Host: %s\r\n" % host)
-    # Iterate over keys to avoid tuple alloc
-    for k in headers:
-        s.write(k)
-        s.write(b": ")
-        s.write(headers[k])
-        s.write(b"\r\n")
-    if json is not None:
-        assert data is None
-        import ujson
-        data = ujson.dumps(json)
-    if data:
-        s.write(b"Content-Length: %d\r\n" % len(data))
-    s.write(b"\r\n")
-    if data:
-        s.write(data)
+    ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
+    ai = ai[0]
 
-    l = s.readline()
-    protover, status, msg = l.split(None, 2)
-    status = int(status)
-    #print(protover, status, msg)
-    while True:
-        l = s.readline()
-        if not l or l == b"\r\n":
-            break
-        #print(l)
-        if l.lower().startswith(b"transfer-encoding:"):
-            if b"chunked" in l:
-                s.close()
-                raise ValueError("Unsupported " + l)
-        elif l.lower().startswith(b"location:") and 300 <= status <= 399:
-            s.close()
-            if redirect <= 0:
-                raise ValueError("Too many redirects")
+    s = usocket.socket(ai[0], ai[1], ai[2])
+    try:
+        s.connect(ai[-1])
+        if proto == "https:":
+            if cert:
+                s = ussl.wrap_socket(s, server_hostname=host, cert=cert)
             else:
-                return request(method, l[9:len(l)].decode().strip(), data, json, headers, stream, timeout, redirect-1)
+                s = ussl.wrap_socket(s, server_hostname=host)
+        s.write(b"%s /%s HTTP/1.0\r\n" % (method, path))
+        if not "Host" in headers:
+            s.write(b"Host: %s\r\n" % host)
+        # Iterate over keys to avoid tuple alloc
+        for k in headers:
+            s.write(k)
+            s.write(b": ")
+            s.write(headers[k])
+            s.write(b"\r\n")
+        if json is not None:
+            assert data is None
+            import ujson
+            data = ujson.dumps(json)
+            s.write(b"Content-Type: application/json\r\n")
+        if data:
+            s.write(b"Content-Length: %d\r\n" % len(data))
+        s.write(b"\r\n")
+        if data:
+            s.write(data)
+
+        l = s.readline()
+        #print(l)
+        l = l.split(None, 2)
+        status = int(l[1])
+        reason = ""
+        if len(l) > 2:
+            reason = l[2].rstrip()
+        while True:
+            l = s.readline()
+            if not l or l == b"\r\n":
+                break
+            #print(l)
+            if l.startswith(b"Transfer-Encoding:"):
+                if b"chunked" in l:
+                    raise ValueError("Unsupported " + l)
+            elif l.startswith(b"Location:") and not 200 <= status <= 299:
+                raise NotImplementedError("Redirects not yet supported")
+    except OSError:
+        s.close()
+        raise
 
     resp = Response(s)
     resp.status_code = status
-    resp.reason = msg.rstrip()
+    resp.reason = reason
     return resp
 
 


### PR DESCRIPTION
Try to offer a bit more security by adding options for checking certificates used when setting up a connection with ussl from within Micropython.

Added functions:

```
ussl.verify_letsencrypt True) # Verify the certificate against Letsencrypt root
ussl.disable_warning(True)  # Disable the new warning
ussl.debug_level(4) # Set MBEDTLS debug level (0-4)
```

Also: the "cert" keyword argument that can be given to ussl.wrap_socket() can now be used to supply either an ASCII (base64) or DER encoded CA certificate to check against.

the "urequests" module has been updated to allow passing through the certificate.

For example: the code down below verifies the against the DigiCert global root CA certificate.

```
cacert = "-----BEGIN CERTIFICATE-----\nMIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh\nMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\nd3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\nQTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT\nMRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\nb20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG\n9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB\nCSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97\nnh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt\n43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P\nT19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4\ngdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO\nBgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR\nTLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw\nDQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr\nhMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg\n06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF\nPnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls\nYSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk\nCAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=\n-----END CERTIFICATE-----\n"

r = urequests_test.get("https://sha256.badssl.com/", cacert=cacert)
```