### PR TITLE
Fixed bug where drawRaw only send the first byte was read

### DIFF
--- a/firmware/components/micropython/esp32/modframebuffer.c
+++ b/firmware/components/micropython/esp32/modframebuffer.c
@@ -138,7 +138,7 @@ static mp_obj_t framebuffer_draw_raw(mp_uint_t n_args, const mp_obj_t *args)
 	}
 	
 	mp_uint_t len;
-	uint8_t *data = (uint8_t *)mp_obj_str_get_data(args[4], &len);
+	uint32_t *data = (uint32_t *)mp_obj_str_get_data(args[4], &len);
 	
 	for (int16_t px = 0; px < w; px++) {
 		for (int16_t py = 0; py < h; py++) {


### PR DESCRIPTION
The function edited `framebuffer_draw_raw` calls in `driver_framebuffer_setPixel`, and passing through the data received, but it only sends the first byte instead of the whole word. As it is simply a cast from an array, it can easily be fixed by casting it to the whole word.

The edit was tested on the Campzone2019 badge, at which it works, but I am unsure if it will fully work with the other badges with different BBP sizes. 