### PR TITLE
Re-add support for onewire

### DIFF
--- a/firmware/components/micropython/component.mk
+++ b/firmware/components/micropython/component.mk
@@ -287,6 +287,7 @@ endif
 
 EXTMOD_SRC_C = $(addprefix extmod/,\
 	modbtree.c \
+	modonewire.c \
 	moducryptolib.c \
 	machine_spi.c \
 	)

--- a/firmware/components/micropython/esp32/mpconfigport.h
+++ b/firmware/components/micropython/esp32/mpconfigport.h
@@ -289,6 +289,7 @@ extern const struct _mp_obj_module_t esp_module;
 extern const struct _mp_obj_module_t espnow_module;
 extern const struct _mp_obj_module_t consts_module;
 extern const struct _mp_obj_module_t loopback_module;
+extern const struct _mp_obj_module_t onewire_module;
 
 #ifdef CONFIG_DRIVER_MPU6050_ENABLE
 extern const struct _mp_obj_module_t mpu6050_module;
@@ -504,6 +505,7 @@ extern const struct _mp_obj_module_t pca9555_module;
 	{ MP_OBJ_NEW_QSTR(MP_QSTR_esp),      (mp_obj_t)&esp_module }, \
 	{ MP_OBJ_NEW_QSTR(MP_QSTR_consts),   (mp_obj_t)&consts_module }, \
 	{ MP_OBJ_NEW_QSTR(MP_QSTR_loopback), (mp_obj_t)&loopback_module }, \
+	{ MP_OBJ_NEW_QSTR(MP_QSTR__onewire), (mp_obj_t)&onewire_module }, \
 	BUILTIN_MODULE_UCRYPTOLIB \
 	BUILTIN_MODULE_SNDMIXER \
 	BUILTIN_MODULE_MICROPHONE \

--- a/firmware/components/micropython/extmod/modonewire.c
+++ b/firmware/components/micropython/extmod/modonewire.c
@@ -1,0 +1,162 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2017 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "py/obj.h"
+#include "py/mphal.h"
+
+/******************************************************************************/
+// Low-level 1-Wire routines
+
+#define TIMING_RESET1 (480)
+#define TIMING_RESET2 (40)
+#define TIMING_RESET3 (420)
+#define TIMING_READ1 (5)
+#define TIMING_READ2 (5)
+#define TIMING_READ3 (40)
+#define TIMING_WRITE1 (10)
+#define TIMING_WRITE2 (50)
+#define TIMING_WRITE3 (10)
+
+STATIC int onewire_bus_reset(mp_hal_pin_obj_t pin) {
+    mp_hal_pin_write(pin, 0);
+    mp_hal_delay_us(TIMING_RESET1);
+    uint32_t i = mp_hal_quiet_timing_enter();
+    mp_hal_pin_write(pin, 1);
+    mp_hal_delay_us_fast(TIMING_RESET2);
+    int status = !mp_hal_pin_read(pin);
+    mp_hal_quiet_timing_exit(i);
+    mp_hal_delay_us(TIMING_RESET3);
+    return status;
+}
+
+STATIC int onewire_bus_readbit(mp_hal_pin_obj_t pin) {
+    mp_hal_pin_write(pin, 1);
+    uint32_t i = mp_hal_quiet_timing_enter();
+    mp_hal_pin_write(pin, 0);
+    mp_hal_delay_us_fast(TIMING_READ1);
+    mp_hal_pin_write(pin, 1);
+    mp_hal_delay_us_fast(TIMING_READ2);
+    int value = mp_hal_pin_read(pin);
+    mp_hal_quiet_timing_exit(i);
+    mp_hal_delay_us_fast(TIMING_READ3);
+    return value;
+}
+
+STATIC void onewire_bus_writebit(mp_hal_pin_obj_t pin, int value) {
+    uint32_t i = mp_hal_quiet_timing_enter();
+    mp_hal_pin_write(pin, 0);
+    mp_hal_delay_us_fast(TIMING_WRITE1);
+    if (value) {
+        mp_hal_pin_write(pin, 1);
+    }
+    mp_hal_delay_us_fast(TIMING_WRITE2);
+    mp_hal_pin_write(pin, 1);
+    mp_hal_delay_us_fast(TIMING_WRITE3);
+    mp_hal_quiet_timing_exit(i);
+}
+
+/******************************************************************************/
+// MicroPython bindings
+
+STATIC mp_obj_t onewire_reset(mp_obj_t pin_in) {
+    return mp_obj_new_bool(onewire_bus_reset(mp_hal_get_pin_obj(pin_in)));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(onewire_reset_obj, onewire_reset);
+
+STATIC mp_obj_t onewire_readbit(mp_obj_t pin_in) {
+    return MP_OBJ_NEW_SMALL_INT(onewire_bus_readbit(mp_hal_get_pin_obj(pin_in)));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(onewire_readbit_obj, onewire_readbit);
+
+STATIC mp_obj_t onewire_readbyte(mp_obj_t pin_in) {
+    mp_hal_pin_obj_t pin = mp_hal_get_pin_obj(pin_in);
+    uint8_t value = 0;
+    for (int i = 0; i < 8; ++i) {
+        value |= onewire_bus_readbit(pin) << i;
+    }
+    return MP_OBJ_NEW_SMALL_INT(value);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(onewire_readbyte_obj, onewire_readbyte);
+
+STATIC mp_obj_t onewire_writebit(mp_obj_t pin_in, mp_obj_t value_in) {
+    onewire_bus_writebit(mp_hal_get_pin_obj(pin_in), mp_obj_get_int(value_in));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(onewire_writebit_obj, onewire_writebit);
+
+STATIC mp_obj_t onewire_writebyte(mp_obj_t pin_in, mp_obj_t value_in) {
+    mp_hal_pin_obj_t pin = mp_hal_get_pin_obj(pin_in);
+    int value = mp_obj_get_int(value_in);
+    for (int i = 0; i < 8; ++i) {
+        onewire_bus_writebit(pin, value & 1);
+        value >>= 1;
+    }
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(onewire_writebyte_obj, onewire_writebyte);
+
+STATIC mp_obj_t onewire_crc8(mp_obj_t data) {
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(data, &bufinfo, MP_BUFFER_READ);
+    uint8_t crc = 0;
+    for (size_t i = 0; i < bufinfo.len; ++i) {
+        uint8_t byte = ((uint8_t*)bufinfo.buf)[i];
+        for (int b = 0; b < 8; ++b) {
+            uint8_t fb_bit = (crc ^ byte) & 0x01;
+            if (fb_bit == 0x01) {
+                crc = crc ^ 0x18;
+            }
+            crc = (crc >> 1) & 0x7f;
+            if (fb_bit == 0x01) {
+                crc = crc | 0x80;
+            }
+            byte = byte >> 1;
+        }
+    }
+    return MP_OBJ_NEW_SMALL_INT(crc);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(onewire_crc8_obj, onewire_crc8);
+
+STATIC const mp_rom_map_elem_t onewire_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_onewire) },
+
+    { MP_ROM_QSTR(MP_QSTR_reset), MP_ROM_PTR(&onewire_reset_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readbit), MP_ROM_PTR(&onewire_readbit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readbyte), MP_ROM_PTR(&onewire_readbyte_obj) },
+    { MP_ROM_QSTR(MP_QSTR_writebit), MP_ROM_PTR(&onewire_writebit_obj) },
+    { MP_ROM_QSTR(MP_QSTR_writebyte), MP_ROM_PTR(&onewire_writebyte_obj) },
+    { MP_ROM_QSTR(MP_QSTR_crc8), MP_ROM_PTR(&onewire_crc8_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(onewire_module_globals, onewire_module_globals_table);
+
+const mp_obj_module_t onewire_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t*)&onewire_module_globals,
+};

--- a/firmware/python_modules/generic/onewire
+++ b/firmware/python_modules/generic/onewire
@@ -1,0 +1,1 @@
+../shared/onewire

--- a/firmware/python_modules/m5stack_atom/onewire
+++ b/firmware/python_modules/m5stack_atom/onewire
@@ -1,0 +1,1 @@
+../shared/onewire

--- a/firmware/python_modules/sha2017/onewire
+++ b/firmware/python_modules/sha2017/onewire
@@ -1,0 +1,1 @@
+../shared/onewire

--- a/firmware/python_modules/shared/onewire/__init__.py
+++ b/firmware/python_modules/shared/onewire/__init__.py
@@ -1,0 +1,2 @@
+from .onewire import OneWire, OneWireError
+from .ds18x20 import DS18X20

--- a/firmware/python_modules/shared/onewire/ds18x20.py
+++ b/firmware/python_modules/shared/onewire/ds18x20.py
@@ -1,0 +1,100 @@
+# DS18x20 temperature sensor driver for MicroPython.
+# MIT license; Copyright (c) 2016 Damien P. George, Copyright (c) 2020 Badge.team
+
+from micropython import const
+import struct
+
+_CONVERT = const(0x44)
+_RD_SCRATCH = const(0xbe)
+_WR_SCRATCH = const(0x4e)
+_TEMP_CONVERT_CELCIUS = const(0x10)
+_DATA_STRUCTURE = '<hBBBBBB'
+_DATA_CONFIG_RESOLUTION_OFFSET = const(5)
+
+class DS18X20:
+    RESOLUTION_9BIT = 0
+    RESOLUTION_10BIT = 1
+    RESOLUTION_11BIT = 2
+    RESOLUTION_12BIT = 3
+
+    def __init__(self, onewire):
+        self.ow = onewire
+        self.buf = bytearray(9)
+
+    def scan(self):
+        return [rom for rom in self.ow.scan() if rom[0] == 0x10 or rom[0] == 0x28]
+
+    def convert_temp(self):
+        self.ow.reset(True)
+        self.ow.writebyte(self.ow.SKIP_ROM)
+        self.ow.writebyte(_CONVERT)
+
+    def read_scratch(self, rom):
+        self.ow.reset(True)
+        self.ow.select_rom(rom)
+        self.ow.writebyte(_RD_SCRATCH)
+        self.ow.readinto(self.buf)
+        if self.ow.crc8(self.buf):
+            raise Exception('CRC error')
+        return self.buf
+
+    def write_scratch(self, rom, buf):
+        self.ow.reset(True)
+        self.ow.select_rom(rom)
+        self.ow.writebyte(_WR_SCRATCH)
+        self.ow.write(buf)
+
+    def parse_scratch(self, data):
+        [temperature, th, tl, config, res1, res2, res3] = struct.unpack(_DATA_STRUCTURE, data)
+        return {
+            'temperature': temperature,
+            'th': th,
+            'tl': tl,
+            'config': config,
+            'res1': res1,
+            'res2': res2,
+            'res3': res3
+        }
+
+    def assemble_scratch(self, data):
+        return struct.pack(
+            _DATA_STRUCTURE,
+            data['temperature'],
+            data['th'],
+            data['tl'],
+            data['config'],
+            data['res1'],
+            data['res2'],
+            data['res3']
+        )
+
+    def set_resolution(self, rom, resolution):
+        if (resolution < self.RESOLUTION_9BIT or resolution > self.RESOLUTION_12BIT):
+            raise ValueError("Resolution is not valid")
+
+        buf = self.read_scratch(rom)
+        data = self.parse_scratch(buf)
+        # The other bits don't care about being written to (r/o)
+        data['config'] = resolution << _DATA_CONFIG_RESOLUTION_OFFSET
+        buf = self.assemble_scratch(data)
+        self.write_scratch(rom, buf)
+
+    def read_temp(self, rom):
+        buf = self.read_scratch(rom)
+        data = self.parse_scratch(buf)
+
+        resolution = (data['config'] >> _DATA_CONFIG_RESOLUTION_OFFSET) & 0x03
+
+        # In the lower resolution modes these bits are not used.
+        # We null them to prevent data inaccuracy
+
+        if (resolution == self.RESOLUTION_9BIT):
+            data['temperature'] &= ~0x07
+        elif (resolution == self.RESOLUTION_10BIT):
+            data['temperature'] &= ~0x03
+        elif (resolution == self.RESOLUTION_11BIT):
+            data['temperature'] &= ~0x01
+
+        data['temperature'] /= _TEMP_CONVERT_CELCIUS
+
+        return data['temperature']

--- a/firmware/python_modules/shared/onewire/onewire.py
+++ b/firmware/python_modules/shared/onewire/onewire.py
@@ -1,0 +1,91 @@
+# 1-Wire driver for MicroPython
+# MIT license; Copyright (c) 2016 Damien P. George
+
+from micropython import const
+import _onewire as _ow
+
+class OneWireError(Exception):
+    pass
+
+class OneWire:
+    SEARCH_ROM = const(0xf0)
+    MATCH_ROM = const(0x55)
+    SKIP_ROM = const(0xcc)
+
+    def __init__(self, pin):
+        self.pin = pin
+        self.pin.init(pin.INOUT_OD, pin.PULL_UP)
+
+    def reset(self, required=False):
+        reset = _ow.reset(self.pin)
+        if required and not reset:
+            raise OneWireError
+        return reset
+
+    def readbit(self):
+        return _ow.readbit(self.pin)
+
+    def readbyte(self):
+        return _ow.readbyte(self.pin)
+
+    def readinto(self, buf):
+        for i in range(len(buf)):
+            buf[i] = _ow.readbyte(self.pin)
+
+    def writebit(self, value):
+        return _ow.writebit(self.pin, value)
+
+    def writebyte(self, value):
+        return _ow.writebyte(self.pin, value)
+
+    def write(self, buf):
+        for b in buf:
+            _ow.writebyte(self.pin, b)
+
+    def select_rom(self, rom):
+        self.reset()
+        self.writebyte(MATCH_ROM)
+        self.write(rom)
+
+    def scan(self):
+        devices = []
+        diff = 65
+        rom = False
+        for i in range(0xff):
+            rom, diff = self._search_rom(rom, diff)
+            if rom:
+                devices += [rom]
+            if diff == 0:
+                break
+        return devices
+
+    def _search_rom(self, l_rom, diff):
+        if not self.reset():
+            return None, 0
+        self.writebyte(SEARCH_ROM)
+        if not l_rom:
+            l_rom = bytearray(8)
+        rom = bytearray(8)
+        next_diff = 0
+        i = 64
+        for byte in range(8):
+            r_b = 0
+            for bit in range(8):
+                b = self.readbit()
+                if self.readbit():
+                    if b: # there are no devices or there is an error on the bus
+                        return None, 0
+                else:
+                    if not b: # collision, two devices with different bit meaning
+                        if diff > i or ((l_rom[byte] & (1 << bit)) and diff != i):
+                            b = 1
+                            next_diff = i
+                self.writebit(b)
+                if b:
+                    r_b |= 1 << bit
+                i -= 1
+            rom[byte] = r_b
+        return rom, next_diff
+
+    def crc8(self, data):
+        return _ow.crc8(data)


### PR DESCRIPTION
In the past (SHA2017) there was support for interfacing with onewire modules. This re-adds support for these type of devices.

This also adds support for setting the resolution on the DS18X20 sensors.